### PR TITLE
Fixes crash in “don’t keep activities” mode

### DIFF
--- a/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/conductor/delegate/MvpConductorLifecycleListener.java
+++ b/mvp/src/main/java/com/hannesdorfmann/mosby3/mvp/conductor/delegate/MvpConductorLifecycleListener.java
@@ -77,10 +77,8 @@ public class MvpConductorLifecycleListener<V extends MvpView, P extends MvpPrese
   public void postDestroy(@NonNull Controller controller) {
     super.postDestroy(controller);
     P presenter = getCallback().getPresenter();
-    if (presenter == null) {
-      throw new NullPointerException(
-              "Presenter returned from getPresenter() is null in " + callback);
+    if (presenter != null) {
+      presenter.destroy();
     }
-    presenter.destroy();
   }
 }


### PR DESCRIPTION
I suggest do not throw exception because of this issue

https://github.com/sockeqwe/mosby-conductor/issues/36